### PR TITLE
Fix avatar picture in auth hash info

### DIFF
--- a/lib/omniauth_open_id_connect.rb
+++ b/lib/omniauth_open_id_connect.rb
@@ -155,7 +155,7 @@ module ::OmniAuth
           first_name: data_source['given_name'],
           last_name: data_source['family_name'],
           nickname: data_source['preferred_username'],
-          picture: data_source['picture']
+          image: data_source['picture']
         )
       end
 


### PR DESCRIPTION
Managed Authenticator expects `image` field, not `picture`:
https://github.com/discourse/discourse/blob/09a97363dac1d5cc7c8e6046216a3b25c1a53c79/lib/auth/managed_authenticator.rb#L87