### PR TITLE
FIX: Gracefully handle errors while fetching the discovery document

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -11,3 +11,6 @@ en:
     openid_connect_verbose_logging: "Log detailed openid-connect authentication information to `/logs`. Keep this disabled during normal use."
     openid_connect_authorize_parameters: "URL parameters which will be included in the redirect from /auth/oidc to the IDP's authorize endpoint"
     openid_connect_overrides_email: "On every login, override the user's email using the openid-connect value"
+  login:
+    omniauth_error:
+      openid_connect_discovery_error: Unable to fetch configuration from identity provider. Please try again.

--- a/lib/openid_connect_authenticator.rb
+++ b/lib/openid_connect_authenticator.rb
@@ -31,11 +31,42 @@ class OpenIDConnectAuthenticator < Auth::ManagedAuthenticator
     SiteSetting.openid_connect_overrides_email
   end
 
+  def discovery_document
+    document_url = SiteSetting.openid_connect_discovery_document.presence
+    if !document_url
+      oidc_log("No discovery document URL specified", error: true)
+      return
+    end
+
+    from_cache = true
+    result = Discourse.cache.fetch("openid-connect-discovery-#{document_url}", expires_in: 10.minutes) do
+      from_cache = false
+      oidc_log("Fetching discovery document from #{document_url}")
+      connection = Faraday.new { |c| c.use Faraday::Response::RaiseError }
+      JSON.parse(connection.get(document_url).body)
+    rescue Faraday::Error, JSON::ParserError => e
+      oidc_log("Fetching discovery document raised error #{e.class} #{e.message}", error: true)
+      nil
+    end
+
+    oidc_log("Discovery document loaded from cache") if from_cache
+    oidc_log("Discovery document is\n\n#{result.to_yaml}")
+
+    result
+  end
+
+  def oidc_log(message, error: false)
+    if error
+      Rails.logger.error("OIDC Log: #{message}")
+    elsif SiteSetting.openid_connect_verbose_logging
+      Rails.logger.warn("OIDC Log: #{message}")
+    end
+  end
+
   def register_middleware(omniauth)
 
     omniauth.provider :openid_connect,
       name: :oidc,
-      cache: lambda { |key, &blk| Rails.cache.fetch(key, expires_in: 10.minutes, &blk) },
       error_handler: lambda { |error, message|
         handlers = SiteSetting.openid_connect_error_redirects.split("\n")
         handlers.each do |row|
@@ -44,10 +75,7 @@ class OpenIDConnectAuthenticator < Auth::ManagedAuthenticator
         end
         nil
       },
-      verbose_logger: lambda { |message|
-        return unless SiteSetting.openid_connect_verbose_logging
-        Rails.logger.warn("OIDC Log: #{message}")
-      },
+      verbose_logger: lambda { |message| oidc_log(message) },
       setup: lambda { |env|
         opts = env['omniauth.strategy'].options
 
@@ -57,9 +85,7 @@ class OpenIDConnectAuthenticator < Auth::ManagedAuthenticator
         opts.deep_merge!(
           client_id: SiteSetting.openid_connect_client_id,
           client_secret: SiteSetting.openid_connect_client_secret,
-          client_options: {
-            discovery_document: SiteSetting.openid_connect_discovery_document,
-          },
+          discovery_document: discovery_document,
           scope: SiteSetting.openid_connect_authorize_scope,
           token_params: token_params,
           passthrough_authorize_options: SiteSetting.openid_connect_authorize_parameters.split("|")

--- a/plugin.rb
+++ b/plugin.rb
@@ -6,6 +6,8 @@
 # authors: David Taylor
 # url: https://github.com/discourse/discourse-openid-connect
 
+enabled_site_setting :openid_connect_enabled
+
 require_relative "lib/openid_connect_faraday_formatter"
 require_relative "lib/omniauth_open_id_connect"
 require_relative "lib/openid_connect_authenticator"


### PR DESCRIPTION
Previously an error loading the discovery document would raise an exception. Now, it will display an error to the user, and log the error for site admins to view at `/logs`. Specs are updated and improved accordingly.

This moves the discovery document fetching out of OmniAuth and into Discourse. This makes it available for the upcoming rp-initiated-logout support.