### PR TITLE
FEATURE: Add support for OIDC RP-initiated logout

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5,6 +5,7 @@ en:
     openid_connect_client_id: "OpenID Connect client ID"
     openid_connect_client_secret: "OpenID Connect client secret"
     openid_connect_authorize_scope: "The scopes sent to the authorize endpoint. This must include 'openid'."
+    openid_connect_rp_initiated_logout: "Redirect the user to end_session_endpoint after logout. Must be supported by your identity provider and included in the discovery document."
     openid_connect_token_scope: "The scopes sent when requesting the token endpoint. The official specification does not require this."
     openid_connect_error_redirects: "If the callback error_reason contains the first parameter, the user will be redirected to the URL in the second parameter"
     openid_connect_allow_association_change: "Allow users to disconnect and reconnect their Discourse accounts from the OpenID Connect provider"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,6 +7,8 @@ plugins:
     default: ""
   openid_connect_client_secret:
     default: ""
+  openid_connect_rp_initiated_logout: 
+    default: false
   openid_connect_allow_association_change:
     default: false
   openid_connect_overrides_email:

--- a/spec/requests/rp_initiated_logout_spec.rb
+++ b/spec/requests/rp_initiated_logout_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe "OIDC RP-Initiated Logout" do
+  let(:document_url) { SiteSetting.openid_connect_discovery_document = "https://id.example.com/.well-known/openid-configuration" }
+  let(:document) do
+    {
+      "issuer": "https://id.example.com/",
+      "authorization_endpoint": "https://id.example.com/authorize",
+      "token_endpoint": "https://id.example.com/token",
+      "userinfo_endpoint": "https://id.example.com/userinfo",
+      "end_session_endpoint": "https://id.example.com/endsession",
+    }.to_json
+  end
+  let(:user) { Fabricate(:user) }
+
+  before do
+    SiteSetting.openid_connect_enabled = true
+    SiteSetting.openid_connect_rp_initiated_logout = true
+    stub_request(:get, document_url).to_return(body: document)
+  end
+
+  after do
+    Discourse.cache.delete("openid-connect-discovery-#{document_url}")
+  end
+
+  it "does nothing for a user with no oidc record" do
+    sign_in(user)
+    delete "/session/#{user.username}", xhr: true
+    expect(response.status).to eq(200)
+    expect(response.parsed_body["redirect_url"]).to eq("/")
+  end
+
+  it "does nothing for a user with no token in their oidc record" do
+    sign_in(user)
+    UserAssociatedAccount.create!(provider_name: "oidc", user: user, provider_uid: "myuid")
+    delete "/session/#{user.username}", xhr: true
+    expect(response.status).to eq(200)
+    expect(response.parsed_body["redirect_url"]).to eq("/")
+  end
+
+  context "with user and token" do
+    before do
+      sign_in(user)
+      UserAssociatedAccount.create!(provider_name: "oidc", user: user, provider_uid: "myuid", credentials: { token: "myoidctoken" })
+    end
+
+    it "redirects the user to the logout endpoint" do
+      delete "/session/#{user.username}", xhr: true
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["redirect_url"]).to eq("https://id.example.com/endsession?id_token_hint=myoidctoken")
+    end
+
+    it "does not redirect if plugin disabled" do
+      SiteSetting.openid_connect_enabled = false
+      delete "/session/#{user.username}", xhr: true
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["redirect_url"]).to eq("/")
+    end
+
+    it "does not redirect if rp initiated logout disabled" do
+      SiteSetting.openid_connect_rp_initiated_logout = false
+      delete "/session/#{user.username}", xhr: true
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["redirect_url"]).to eq("/")
+    end
+
+    it "does not redirect if the discovery document is missing the endpoint" do
+      stub_request(:get, document_url).to_return(body: "{}")
+      SiteSetting.openid_connect_rp_initiated_logout = false
+      delete "/session/#{user.username}", xhr: true
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["redirect_url"]).to eq("/")
+    end
+
+    it "does not redirect if the discovery document has a network error" do
+      stub_request(:get, document_url).to_timeout
+      SiteSetting.openid_connect_rp_initiated_logout = false
+      delete "/session/#{user.username}", xhr: true
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["redirect_url"]).to eq("/")
+    end
+
+  end
+
+end


### PR DESCRIPTION
Based on the specification at https://openid.net/specs/openid-connect-rpinitiated-1_0.html

When logging out, this feature will redirect the user to the end_session_url from the discovery document. Their most recent id token will be included in the `id_token_hint` parameter.

To use this, the identity provider must include an end_session_url in the discovery document, and the openid_connect_rp_initiated_logout site setting must be enabled.