### PR TITLE
Handle groups 

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,3 +29,9 @@ plugins:
     default: ''
     type: list
     list_type: compact
+  openid_connect_handle_groups:
+    default: false
+  openid_connect_create_groups:
+    default: true
+  openid_connect_strict_groups:
+    default: true

--- a/lib/omniauth_open_id_connect.rb
+++ b/lib/omniauth_open_id_connect.rb
@@ -151,7 +151,8 @@ module ::OmniAuth
           first_name: data_source['given_name'],
           last_name: data_source['family_name'],
           nickname: data_source['preferred_username'],
-          image: data_source['picture']
+          image: data_source['picture'],
+          groups: data_source['groups']
         )
       end
 

--- a/spec/lib/openid_connect_authenticator_spec.rb
+++ b/spec/lib/openid_connect_authenticator_spec.rb
@@ -11,7 +11,8 @@ describe OpenIDConnectAuthenticator do
     uid: "123456789",
     info: {
         name: "John Doe",
-        email: user.email
+        email: user.email,
+        groups: ['staff', 'losers']
     },
     extra: {
       raw_info: {


### PR DESCRIPTION
As discussed in [a comment on the plugin post](https://meta.discourse.org/t/openid-connect-authentication-plugin/103632/131?u=mcaruanagalizia) and in a separate post [asking for proposals](https://meta.discourse.org/t/paid-groups-synchronisation-for-discourse-oidc-plugin/173332). Would appreciate some help with tests as I am not an experienced Ruby developer.

Introduces three new settings:

 - `openid_connect_handle_groups` will activate the code path for handling groups in the token
 - `openid_connect_create_groups` will create groups that the IdP user is a member of but that are not present in Discourse
 - `openid_connect_strict_groups` will remove user from Discourse groups that are not present in the token