### PR TITLE
FIX: Only send `claims` parameter if it has been set

### DIFF
--- a/lib/omniauth_open_id_connect.rb
+++ b/lib/omniauth_open_id_connect.rb
@@ -72,7 +72,7 @@ module ::OmniAuth
             params[k] = request.params[k.to_s] unless [nil, ''].include?(request.params[k.to_s])
           end
 
-          if options[:claims]
+          if options[:claims].present?
             params[:claims] = options[:claims]
           end
 

--- a/spec/lib/omniauth_open_id_connect_spec.rb
+++ b/spec/lib/omniauth_open_id_connect_spec.rb
@@ -90,8 +90,13 @@ describe OmniAuth::Strategies::OpenIDConnect do
         expect(subject.session['omniauth.nonce']).to eq(nonce)
       end
 
-      it "passes claims through to authorize endpoint" do
+      it "passes claims through to authorize endpoint if present" do
         expect(subject.authorize_params[:claims]).to eq('{"userinfo":{"email":null,"email_verified":null}')
+      end
+
+      it "does not pass claims if empty string" do
+        subject.options.claims = ""
+        expect(subject.authorize_params[:claims]).to eq(nil)
       end
     end
 


### PR DESCRIPTION
Follow-up to 25454d6707e978b8a9cf143b18b645b60500567b