### PR TITLE
Allow pulling email from emails list

### DIFF
--- a/lib/omniauth_open_id_connect.rb
+++ b/lib/omniauth_open_id_connect.rb
@@ -162,7 +162,7 @@ module ::OmniAuth
         data_source = options.use_userinfo ? userinfo_response : id_token_info
         prune!(
           name: data_source['name'],
-          email: data_source['email'] || data_source['emails'.first()],
+          email: data_source['email'] || data_source['emails'].first(),
           first_name: data_source['given_name'],
           last_name: data_source['family_name'],
           nickname: data_source['preferred_username'],

--- a/lib/omniauth_open_id_connect.rb
+++ b/lib/omniauth_open_id_connect.rb
@@ -162,7 +162,7 @@ module ::OmniAuth
         data_source = options.use_userinfo ? userinfo_response : id_token_info
         prune!(
           name: data_source['name'],
-          email: data_source['email'],
+          email: data_source['email'] || data_source['emails'.first()],
           first_name: data_source['given_name'],
           last_name: data_source['family_name'],
           nickname: data_source['preferred_username'],


### PR DESCRIPTION
Some SSO providers (Azure B2C) don't provide the `email` claim by default, and instead, provide an `emails` claim. This PR simply pulls the first email in the `emails` claim. Tested as working on my installation.