### PR TITLE
DEV: Correct `timeout` spelling

### DIFF
--- a/lib/openid_connect_authenticator.rb
+++ b/lib/openid_connect_authenticator.rb
@@ -108,6 +108,6 @@ class OpenIDConnectAuthenticator < Auth::ManagedAuthenticator
   end
 
   def request_timeout_seconds
-    GlobalSetting.openid_connect_request_timout_seconds
+    GlobalSetting.openid_connect_request_timeout_seconds
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -13,7 +13,7 @@ require_relative "lib/openid_connect_faraday_formatter"
 require_relative "lib/omniauth_open_id_connect"
 require_relative "lib/openid_connect_authenticator"
 
-GlobalSetting.add_default :openid_connect_request_timout_seconds, 10
+GlobalSetting.add_default :openid_connect_request_timeout_seconds, 10
 
 # RP-initiated logout
 # https://openid.net/specs/openid-connect-rpinitiated-1_0.html


### PR DESCRIPTION
Followup to 13c74cdb8378701f48056b88ce1c90e9577f3863