### PR TITLE
Allow to match by username

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -10,6 +10,7 @@ en:
     openid_connect_token_scope: "The scopes sent when requesting the token endpoint. The official specification does not require this."
     openid_connect_error_redirects: "If the callback error_reason contains the first parameter, the user will be redirected to the URL in the second parameter"
     openid_connect_allow_association_change: "Allow users to disconnect and reconnect their Discourse accounts from the OpenID Connect provider"
+    openid_connect_username_association_change: "User are matched and logged in based on username instead of email. Enable this only if your identity provider provides unique usernames."
     openid_connect_verbose_logging: "Log detailed openid-connect authentication information to `/logs`. Keep this disabled during normal use."
     openid_connect_authorize_parameters: "URL parameters which will be included in the redirect from /auth/oidc to the IDP's authorize endpoint"
     openid_connect_overrides_email: "On every login, override the user's email using the openid-connect value. Works the same as the `auth_overrides_email` setting, but is specific to OpenID Connect logins."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,6 +13,8 @@ plugins:
     default: ""
   openid_connect_allow_association_change:
     default: false
+  openid_connect_username_association_change:
+    default: false
   openid_connect_overrides_email:
     default: false
   openid_connect_authorize_scope:

--- a/lib/openid_connect_authenticator.rb
+++ b/lib/openid_connect_authenticator.rb
@@ -32,6 +32,14 @@ class OpenIDConnectAuthenticator < Auth::ManagedAuthenticator
     SiteSetting.openid_connect_overrides_email
   end
 
+  def match_by_email
+    !match_by_username
+  end
+
+  def match_by_username
+    SiteSetting.openid_connect_username_association_change
+  end
+
   def discovery_document
     document_url = SiteSetting.openid_connect_discovery_document.presence
     if !document_url


### PR DESCRIPTION
Allows to match with oidc provided usernames to log in, for openid connect systems that have unique usernames.