### PR TITLE
DEV: Change settings root from plugins: to discourse_openid_connect

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,4 +1,9 @@
 en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_openid_connect: "Discourse OpenID Connect"
   js:
     login:
       oidc:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_openid_connect:
   openid_connect_enabled:
     default: false
   openid_connect_discovery_document:


### PR DESCRIPTION
This is so the plugins settings are better categorized in the site settings UI.