### PR TITLE
DEV: Case insensitive check on email_verified field

### DIFF
--- a/lib/openid_connect_authenticator.rb
+++ b/lib/openid_connect_authenticator.rb
@@ -24,7 +24,8 @@ class OpenIDConnectAuthenticator < Auth::ManagedAuthenticator
       true
     else
       # Many providers violate the spec, and send this as a string rather than a boolean
-      supplied_verified_boolean == true || supplied_verified_boolean == "true"
+      supplied_verified_boolean == true ||
+        (supplied_verified_boolean.is_a?(String) && supplied_verified_boolean.downcase == "true")
     end
   end
 

--- a/spec/lib/openid_connect_authenticator_spec.rb
+++ b/spec/lib/openid_connect_authenticator_spec.rb
@@ -45,6 +45,12 @@ describe OpenIDConnectAuthenticator do
       result = authenticator.after_authenticate(hash)
       expect(result.user).to eq(user)
     end
+
+    it "matches the user as a titlecase true string" do
+      hash[:extra][:raw_info][:email_verified] = "True"
+      result = authenticator.after_authenticate(hash)
+      expect(result.user).to eq(user)
+    end
   end
 
   context "when email_verified is false" do


### PR DESCRIPTION
[Wicket](https://wicket.io/) seems to be providing `email_verified` as `"True"`, so we're making our checks less sensitive.