### PR TITLE
DEV: Raise errors if verbose logging is enabled

### DIFF
--- a/lib/openid_connect_authenticator.rb
+++ b/lib/openid_connect_authenticator.rb
@@ -125,6 +125,10 @@ class OpenIDConnectAuthenticator < Auth::ManagedAuthenticator
                             builder.request :url_encoded # form-encode POST params
                             builder.adapter FinalDestination::FaradayAdapter # make requests with FinalDestination::HTTP
                           end
+
+                          opts[:client_options][
+                            :raise_errors
+                          ] = SiteSetting.openid_connect_verbose_logging
                         }
   end
 


### PR DESCRIPTION
Some exceptions are caught and `nil` is returned instead. This can lead to some errors be silently ignored.