### PR TITLE
DEV: Revert verbose logging commit

### DIFF
--- a/lib/openid_connect_authenticator.rb
+++ b/lib/openid_connect_authenticator.rb
@@ -125,10 +125,6 @@ class OpenIDConnectAuthenticator < Auth::ManagedAuthenticator
                             builder.request :url_encoded # form-encode POST params
                             builder.adapter FinalDestination::FaradayAdapter # make requests with FinalDestination::HTTP
                           end
-
-                          opts[:client_options][
-                            :raise_errors
-                          ] = SiteSetting.openid_connect_verbose_logging
                         }
   end
 


### PR DESCRIPTION
This change was introduced to aid debugging, but it has not proved to be useful.

This reverts commit 90d0df12b2dff3273c8e866f235e265f950a8dd4.